### PR TITLE
Do not set values of unexported fields

### DIFF
--- a/gosecretive.go
+++ b/gosecretive.go
@@ -28,7 +28,8 @@ var DefaultOnValueFuncHandler = func(fieldPath string, valueToScrub interface{})
 }
 
 // Scrub will scrub the given object. if not scrubFuncHandler is given, default to DefaultOnValueFuncHandler.
-// returns the scrubbed object and a map of the scrubbed data
+// returns the scrubbed object and a map of the scrubbed data.
+// if the object contains unexported fields, they will be ignored and won't be in the scrubbed object.
 // e.g.:
 // 	original := map[string]interface{}{
 // 	    "field": "value",

--- a/gosecretive.go
+++ b/gosecretive.go
@@ -147,18 +147,22 @@ func travel(fieldPath string,
 
 	// value is a string. call the callback
 	case reflect.String:
-		newContent := callback(fieldPath, original.Interface())
+		if travelValue.CanSet() {
+			newContent := callback(fieldPath, original.Interface())
 
-		// callback returns a new value to set (override)
-		if newContent != nil && original.String() != *newContent {
-			secrets[*newContent] = original.String()
-			travelValue.SetString(*newContent)
-		} else {
-			travelValue.SetString(original.String())
+			// callback returns a new value to set (override)
+			if newContent != nil && original.String() != *newContent {
+				secrets[*newContent] = original.String()
+				travelValue.SetString(*newContent)
+			} else {
+				travelValue.SetString(original.String())
+			}
 		}
 
 	default:
-		travelValue.Set(original)
+		if travelValue.CanSet() {
+			travelValue.Set(original)
+		}
 	}
 
 }

--- a/gosecretive_test.go
+++ b/gosecretive_test.go
@@ -300,6 +300,28 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSkipUnxportedFields(t *testing.T) {
+	t.Run("SkipUnexportedFields", func(t *testing.T) {
+		type structWithUnexported struct {
+			Exported   string
+			unexported string
+		}
+		s := structWithUnexported{
+			Exported:   "exported",
+			unexported: "unexported",
+		}
+		scrubbedObject, _ := Scrub(s, scrubbingFunction([]string{
+			"/unexported",
+		}))
+		if scrubbedObject.(structWithUnexported).unexported == s.unexported || scrubbedObject.(structWithUnexported).unexported != "" {
+			t.Errorf("Unexported field wasn't skipped. scrubbedObject = %v, expectedRestoredObject %v", scrubbedObject, s)
+		}
+		if scrubbedObject.(structWithUnexported).Exported != s.Exported {
+			t.Errorf("Exported field should not be modified. scrubbedObject = %v, expectedRestoredObject %v", scrubbedObject, s)
+		}
+	})
+}
+
 func scrubbingFunction(allowedFieldPaths []string) OnValueFuncHandler {
 	return func(fieldPath string, valueToScrub interface{}) *string {
 		if stringInSlice(fieldPath, allowedFieldPaths) {


### PR DESCRIPTION
If the structure we're trying to scrub has unexported fields, setting them using reflect's `Set()` or `.Interface()` panic on using and unexported field.

In this PR we skip those fields, meaning they won't be present in scrubbed object (or set to their zero value).